### PR TITLE
Reinstate coverage.py now that 6.x is out

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==21.9b0
 bokeh==2.4.1
 bullet==2.2.0
-# coverage==5.5
+coverage==6.0.2
 django-axes==5.26.0
 django-log-request-id==1.7.0
 django-ninja==0.15.0


### PR DESCRIPTION
Putting coverage back now that 6.x is out.  Previously I commented it out as the latest 5.x version was being flagged as vulnerable by pypi.